### PR TITLE
Add TypeScript (+ React) support

### DIFF
--- a/packages/eslint-config-react-typescript/index.js
+++ b/packages/eslint-config-react-typescript/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: [
+    "@mollie/eslint-config-react",
+    "@mollie/eslint-config-typescript",
+  ],
+  parserOptions: {
+    jsx: true,
+    useJSXTextNode: true,
+  },
+};

--- a/packages/eslint-config-react-typescript/package.json
+++ b/packages/eslint-config-react-typescript/package.json
@@ -9,7 +9,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "eslint": ">= 3"
+    "eslint": ">= 5.12.1",
+    "typescript": ">= 3.2.1"
   },
   "dependencies": {
     "@mollie/eslint-config-react": "^0.0.1-alpha.3",

--- a/packages/eslint-config-react-typescript/package.json
+++ b/packages/eslint-config-react-typescript/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@mollie/eslint-config-react-typescript",
+  "version": "0.0.1-alpha.4",
+  "description": "Mollie's ESLint configuration preset for React + TypeScript.",
+  "main": "index.js",
+  "author": "Mollie B.V. <info@mollie.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "eslint": ">= 3"
+  },
+  "dependencies": {
+    "@mollie/eslint-config-react": "^0.0.1-alpha.3",
+    "@mollie/eslint-config-typescript": "^0.0.1-alpha.3"
+  }
+}

--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -6,4 +6,9 @@ module.exports = {
     "jsx-a11y/label-has-for": "warn",
     "react/sort-comp": "error",
   },
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
 };

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: [
+    "@mollie/eslint-config-base",
+    "plugin:@typescript-eslint/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
+  rules: {
+    "@typescript-eslint/interface-name-prefix": [
+      "error",
+      "always",
+    ],
+    "@typescript-eslint/indent": [
+      "error",
+      2,
+    ],
+    "@typescript-eslint/array-type": [
+      "error",
+      "generic",
+    ],
+  },
+};

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@mollie/eslint-config-react",
+  "name": "@mollie/eslint-config-typescript",
   "version": "0.0.1-alpha.4",
-  "description": "Mollie's ESLint configuration preset for React.",
+  "description": "Mollie's ESLint configuration preset for TypeScript.",
   "main": "index.js",
   "author": "Mollie B.V. <info@mollie.com>",
   "license": "MIT",
@@ -13,8 +13,7 @@
   },
   "dependencies": {
     "@mollie/eslint-config-base": "^0.0.1-alpha.3",
-    "eslint-config-react-app": "^2.1.0",
-    "eslint-plugin-jsx-a11y": "5.1.1",
-    "eslint-plugin-react": "^7.6.1"
+    "@typescript-eslint/eslint-plugin": "^1.3.0",
+    "@typescript-eslint/parser": "^1.3.0"
   }
 }

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -9,12 +9,12 @@
     "access": "public"
   },
   "peerDependencies": {
-    "eslint": ">= 3"
+    "eslint": ">= 5.12.1",
+    "typescript": ">= 3.2.1"
   },
   "dependencies": {
     "@mollie/eslint-config-base": "^0.0.1-alpha.3",
     "@typescript-eslint/eslint-plugin": "^1.3.0",
-    "@typescript-eslint/parser": "^1.3.0",
-    "typescript": "^3.3.3"
+    "@typescript-eslint/parser": "^1.3.0"
   }
 }

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@mollie/eslint-config-base": "^0.0.1-alpha.3",
     "@typescript-eslint/eslint-plugin": "^1.3.0",
-    "@typescript-eslint/parser": "^1.3.0"
+    "@typescript-eslint/parser": "^1.3.0",
+    "typescript": "^3.3.3"
   }
 }


### PR DESCRIPTION
Adds eslint configs for TypeScript and React as used in https://github.com/mollie/mollie-api-node and https://github.com/mollie/PrestaShop