### PR TITLE
Prevent use of .only in test suites.

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -3,7 +3,7 @@ module.exports = {
    * Extending works from right to left. The rules inside the package on the right will always "win"
    * from the rules that are defined in the packages on the left side.
    */
-  plugins: ["import"],
+  plugins: ["import", "no-only-tests"],
   rules: {
     "import/default": "error",
     "import/named": "error",
@@ -12,5 +12,6 @@ module.exports = {
     "no-unused-vars": "error",
     "no-console": "warn",
     "default-case": "off",
+    "no-only-tests/no-only-tests": "error"
   },
 };

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -12,6 +12,7 @@
     "eslint": ">= 3"
   },
   "dependencies": {
-    "eslint-plugin-import": "^2.8.0"
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-no-only-tests": "^2.3.1"
   }
 }


### PR DESCRIPTION
This PR prevents us from leaving instances of `.only` in our codebase, making sure all tests are run unless they’re explicitly skipped.